### PR TITLE
Update operator install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ awx_cache_valid_time: 3600
 awx_operator_src_dir: '/opt/awx_operator'
 
 # Operator version used to deploy awx.
-awx_operator_version: 1.0.0
+awx_operator_version: 2.5.0
 
 # Target namespace for awx operator and instance.
 awx_namespace: default

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,21 @@
 # Cache update time for apt module.
 awx_cache_valid_time: 3600
 
+# Operator src dir.
+awx_operator_src_dir: '/opt/awx_operator'
+
+# Operator git repository
+awx_operator_git_repo: 'https://github.com/ansible/awx-operator.git'
+
 # Operator version used to deploy awx.
-awx_operator_version: 0.13.0
+awx_operator_version: 0.15.0
 
 # Target namespace for awx operator and instance.
 awx_namespace: default
+
+# User used for managing k8s with kube
+awx_kubectl_user: root
+
 
 # Create and manage awx CRD directly in the role.
 # awx_crd:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,8 @@ awx_cache_valid_time: 3600
 # Operator src dir.
 awx_operator_src_dir: '/opt/awx_operator'
 
-# Operator git repository
-awx_operator_git_repo: 'https://github.com/ansible/awx-operator.git'
-
 # Operator version used to deploy awx.
-awx_operator_version: 0.15.0
+awx_operator_version: 0.20.1
 
 # Target namespace for awx operator and instance.
 awx_namespace: default

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ awx_cache_valid_time: 3600
 awx_operator_src_dir: '/opt/awx_operator'
 
 # Operator version used to deploy awx.
-awx_operator_version: 0.20.1
+awx_operator_version: 1.0.0
 
 # Target namespace for awx operator and instance.
 awx_namespace: default

--- a/molecule/microk8s/converge.yml
+++ b/molecule/microk8s/converge.yml
@@ -1,0 +1,41 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    awx_namespace: awx
+    awx_kubectl_user: root
+    awx_crd:
+      apiVersion: awx.ansible.com/v1beta1
+      kind: AWX
+      metadata:
+        name: awx
+      spec:
+        service_type: nodeport
+        nodeport_port: 30080
+        ingress_type: ingress
+        hostname: awx.test.com
+        web_resource_requirements:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        task_resource_requirements:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        ee_resource_requirements:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+  tasks:
+    - name: "Include ansible-role-awx"
+      include_role:
+        name: "ansible-role-awx"

--- a/molecule/microk8s/molecule.yml
+++ b/molecule/microk8s/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-certs: true
+    ignore-errors: true
+driver:
+  name: vagrant
+platforms:
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 4048
+    cpus: 4
+    instance_raw_config_args:
+      - "vm.network 'forwarded_port', guest: 8081, host: 30080"
+provisioner:
+  name: ansible
+  lint: ansible-lint --force-color
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+verifier:
+  name: ansible

--- a/molecule/microk8s/prepare.yml
+++ b/molecule/microk8s/prepare.yml
@@ -1,0 +1,76 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  vars:
+    timezone: Europe/Berlin
+    locales: ['en_US.UTF-8']
+    microk8s_plugins:
+      - ingress: true
+      - storage: true
+      - dns: true
+      - helm: true
+      - helm3: true
+      - dashboard: true
+    microk8s_users: ['vagrant', 'root']
+    microk8s_dns_servers: ['8.8.8.8', '8.8.4.4']
+    locale: |
+      LANG=en_US.UTF-8
+      LANGUAGE=en_US.UTF-8
+      LC_CTYPE="en_US.UTF-8"
+      LC_NUMERIC="de_DE.UTF-8"
+      LC_TIME="de_DE.UTF-8"
+      LC_COLLATE="en_US.UTF-8"
+      LC_MONETARY="de_DE.UTF-8"
+      LC_MESSAGES="en_US.UTF-8"
+      LC_PAPER="de_DE.UTF-8"
+      LC_NAME="en_US.UTF-8"
+      LC_ADDRESS="de_DE.UTF-8"
+      LC_TELEPHONE="de_DE.UTF-8"
+      LC_MEASUREMENT="de_DE.UTF-8"
+      LC_IDENTIFICATION="en_US.UTF-8"
+      LC_ALL=en_US.UTF-8
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'
+
+    - name: Install dependencies
+      ansible.builtin.package:
+        name:
+          - python3-pip
+          - tzdata
+          - locales
+
+    - name: Install python dependencies
+      ansible.builtin.pip:
+        name:
+          - openshift
+          - kubernetes
+
+    - name: ensure timezone is correct
+      timezone:
+        name: "{{ item }}"
+      with_items:
+        - "{{ timezone }}"
+
+    - name: Ensure locales exist
+      locale_gen:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - "{{ locales }}"
+
+    - name: Place locale config
+      ansible.builtin.copy:
+        content: "{{ locale }}"
+        dest: /etc/default/locale
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Install microk8s
+      ansible.builtin.include_role:
+        name: "racqspace.microk8s"

--- a/molecule/microk8s/requirements.yml
+++ b/molecule/microk8s/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles:
+  - name: racqspace.microk8s

--- a/molecule/microk8s/verify.yml
+++ b/molecule/microk8s/verify.yml
@@ -1,0 +1,98 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  vars:
+    awx_namespace: awx
+    awx_kubectl_user: root
+  become: true
+  become_user: root
+  tasks:
+    - name: Wait until pods started
+      pause:
+        seconds: 60
+
+    - name: Wait for all control-plane pods become created
+      shell: "kubectl get pods --namespace={{ awx_namespace }}"
+      register: awx_pods_created
+      until: item in awx_pods_created.stdout
+      retries: 10
+      delay: 20
+      with_items:
+        - awx-operator-controller-manager
+        - awx-postgres
+        - 4/4
+
+    - name: Wait for control-plane pods become ready
+      shell: >-
+        kubectl wait --namespace=awx
+        --for=condition=Ready pods
+        --timeout=600s
+        --selector app.kubernetes.io/managed-by=awx-operator
+      register: control_plane_pods_ready
+
+    - name: Get awx operator
+      community.kubernetes.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ awx_namespace }}"
+        label_selectors:
+          - "control-plane=controller-manager"
+      register: awx_operator_querry
+
+    - name: Set awx operator var
+      ansible.builtin.set_fact:
+        awx_operator: "{{ awx_operator_querry.resources | first }}"
+
+    - name: Check awx operator pod
+      ansible.builtin.assert:
+        that:
+          - "'awx-operator-controller-manager' in awx_operator.spec.serviceAccount"
+          - "'Running' in awx_operator.status.phase"
+
+    - name: Get awx postgres
+      community.kubernetes.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ awx_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/instance=postgres-awx"
+      register: awx_postgres_querry
+
+    - name: Set awx postgres var
+      ansible.builtin.set_fact:
+        awx_postgres: "{{ awx_postgres_querry.resources | first }}"
+
+    - name: Check awx postgres pod
+      ansible.builtin.assert:
+        that:
+          - "'awx-postgres-0' in awx_postgres.spec.hostname"
+          - "'Running' in awx_operator.status.phase"
+
+    - name: Get awx pod
+      community.kubernetes.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ awx_namespace }}"
+        label_selectors:
+          - "app.kubernetes.io/name=awx"
+      register: awx_pods_querry
+
+    - name: Set awx var
+      ansible.builtin.set_fact:
+        awx_pods: "{{ awx_pods_querry.resources | first }}"
+
+    - name: Set awx containers
+      ansible.builtin.set_fact:
+        awx_containers: "{{ awx_pods.spec.containers | map(attribute='name') | list }}"
+
+    - name: Check awx pod
+      ansible.builtin.assert:
+        that:
+          - "'awx-web' in awx_containers"
+          - "'awx-task' in awx_containers"
+          - "'awx-ee' in awx_containers"
+          - "'redis' in awx_containers"
+          - "'Running' in awx_pods.status.phase"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,21 +20,26 @@
     - awx
     - awx.dependencies
 
-- name: Create temporary file for awx operator manifest
-  ansible.builtin.tempfile:
-    state: file
-    suffix: awx
-  register: awx_operator_tempfile
+- name: Create dir for awx operator repo
+  ansible.builtin.file:
+    path: "{{ awx_operator_src_dir }}"
+    state: directory
+    owner: "{{ awx_kubectl_user }}"
+    group: "{{ awx_kubectl_user }}"
+    mode: '0755'
+  become: true
   tags:
     - awx
     - awx.operator
-    - molecule-idempotence-notest
 
-- name: Download awx operator manifest
-  ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/ansible/awx-operator/{{ awx_operator_version }}/deploy/awx-operator.yaml"   # yamllint disable-line rule:line-length
-    dest: "{{ awx_operator_tempfile.path }}"
-    mode: '0664'
+- name: Clone awx operator repo
+  ansible.builtin.git:
+    repo: "{{ awx_operator_git_repo }}"
+    dest: "{{ awx_operator_src_dir }}"
+    version: "{{ awx_operator_version }}"
+    force: true
+  become: true
+  become_user: "{{ awx_kubectl_user }}"
   tags:
     - awx
     - awx.operator
@@ -52,10 +57,16 @@
     - awx.operator
 
 - name: Install awx operator
-  kubernetes.core.k8s:
-    state: present
-    src: "{{ awx_operator_tempfile.path }}"
-    namespace: "{{ awx_namespace }}"
+  ansible.builtin.command:
+    cmd: make deploy
+  args:
+    chdir: "{{ awx_operator_src_dir }}"
+  environment:
+    NAMESPACE: "{{ awx_namespace }}"
+  become: true
+  become_user: "{{ awx_kubectl_user }}"
+  register: operator_install
+  changed_when: "'created' in operator_install.stdout"
   tags:
     - awx
     - awx.operator

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
     - awx
     - awx.dependencies
 
-- name: Create dir for awx operator repo
+- name: Create dir for awx operator config files
   ansible.builtin.file:
     path: "{{ awx_operator_src_dir }}"
     state: directory
@@ -32,37 +32,47 @@
     - awx
     - awx.operator
 
-- name: Clone awx operator repo
-  ansible.builtin.git:
-    repo: "{{ awx_operator_git_repo }}"
-    dest: "{{ awx_operator_src_dir }}"
-    version: "{{ awx_operator_version }}"
-    force: true
+- name: Install kustomize
+  ansible.builtin.shell: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+  args:
+    chdir: "{{ awx_operator_src_dir }}"
   become: true
-  become_user: "{{ awx_kubectl_user }}"
+  become_user: 'root'
+  register: kustomize_install
+  changed_when: "'installed' in kustomize_install.stdout"
+  failed_when: false
+  tags:
+    - awx
+    - awx.dependencies
+
+- name: Create kustomize config
+  ansible.builtin.template:
+    src: 'kustomization.yaml.j2'
+    dest: "{{ awx_operator_src_dir }}/kustomization.yaml"
+    owner: "{{ awx_kubectl_user }}"
+    group: "{{ awx_kubectl_user }}"
+    mode: '0744'
+  become: true
   tags:
     - awx
     - awx.operator
-    - molecule-idempotence-notest
 
-- name: create awx namespace
-  kubernetes.core.k8s:
-    name: "{{ awx_namespace }}"
-    api_version: v1
-    kind: Namespace
-    state: present
+- name: Create awx custom resource def
+  ansible.builtin.template:
+    src: 'awx-crd.yaml.j2'
+    dest: "{{ awx_operator_src_dir }}/awx-crd.yaml"
+    owner: "{{ awx_kubectl_user }}"
+    group: "{{ awx_kubectl_user }}"
+    mode: '0744'
+  become: true
   tags:
     - awx
-    - awx.instance
     - awx.operator
 
 - name: Install awx operator
-  ansible.builtin.command:
-    cmd: make deploy
+  ansible.builtin.shell: /opt/awx_operator/kustomize build . | kubectl apply -f -
   args:
     chdir: "{{ awx_operator_src_dir }}"
-  environment:
-    NAMESPACE: "{{ awx_namespace }}"
   become: true
   become_user: "{{ awx_kubectl_user }}"
   register: operator_install
@@ -72,13 +82,27 @@
     - awx.operator
     - molecule-idempotence-notest
 
-- name: Deploy CRDs
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ awx_crd }}"
-    namespace: "{{ awx_namespace }}"
-  when: awx_crd is defined
+- name: Add awx config file to kustomize crd conf file
+  ansible.builtin.lineinfile:
+    dest: "{{ awx_operator_src_dir }}/kustomization.yaml"
+    insertafter: "  # Awx CRD"
+    line: '  - awx-crd.yaml'
+  become: true
   tags:
     - awx
-    - awx.crd
+    - awx.operator
+    - molecule-idempotence-notest
+
+- name: Install awx
+  ansible.builtin.shell: /opt/awx_operator/kustomize build . | kubectl apply -f -
+  args:
+    chdir: "{{ awx_operator_src_dir }}"
+  become: true
+  become_user: "{{ awx_kubectl_user }}"
+  register: operator_install
+  changed_when: "'created' in operator_install.stdout"
+  tags:
+    - awx
+    - awx.operator
+    - molecule-idempotence-notest
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,9 @@
 ---
-- name: Install dependencies
+- name: Install ansible dependencies
   ansible.builtin.apt:
     name:
-      - python3-pip
-    state: present
-    update_cache: true
-    cache_valid_time: "{{ awx_cache_valid_time }}"
-  tags:
-    - awx
-    - awx.dependencies
-
-- name: Install ansible dependencies
-  ansible.builtin.pip:
-    name:
-      - kubernetes
-      - openshift
-      - pyyaml
+      - python3-kubernetes
+      - python3-openshift
   tags:
     - awx
     - awx.dependencies

--- a/templates/awx-crd.yaml.j2
+++ b/templates/awx-crd.yaml.j2
@@ -1,0 +1,2 @@
+---
+{{ awx_crd | to_nice_yaml(indent=2) }}

--- a/templates/kustomization.yaml.j2
+++ b/templates/kustomization.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Find the latest tag here: https://github.com/ansible/awx-operator/releases
+  - github.com/ansible/awx-operator/config/default?ref={{ awx_operator_version }}
+  # Awx CRD
+
+# Set the image tags to match the git version from above
+images:
+  - name: quay.io/ansible/awx-operator
+    newTag: {{ awx_operator_version }}
+
+# Specify a custom namespace in which to install AWX
+namespace: {{ awx_namespace }}


### PR DESCRIPTION
From 0.14.0 onward the operator needs to be installed with `make` via the awx operator repository.
Added the new install way and a molecule test using vagrant and microk8s.